### PR TITLE
Optional Model-View Engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,8 +218,8 @@ Arcane ships with a built-in, regex-powered MV engine. Simply create an `.html` 
 
 Values output using the engine are automatically wrapped in `htmlspecialchars()` to protect your application from XSS attacks by default.
 
-  - **Shorthand (`:`):** Best for simple variables and object methods (`:$title`, `:$user->getName()`). *Note: Shorthand does not support array brackets. Use the implicit echo instead.*
-  - **Implicit (`:=`):** Best for arrays, complex expressions, or string interpolation. When interpolating strings, use single quotes on the outside and double quotes on the inside: `:='"Welcome back, {$user->name}"'`.
+  - **Shorthand (`:`):** Best for simple variables and object methods. Does not support array brackets.
+  - **Implicit (`:=`):** Best for arrays, complex expressions, or string interpolation. When interpolating, use single quotes on the outside and double quotes on the inside.
   - **Explicit (`<echo>`):** The explicit HTML-style tag for outputting expressions.
 
 ```html
@@ -230,6 +230,7 @@ Values output using the engine are automatically wrapped in `htmlspecialchars()`
 <!-- Implicit (equals used, quotes required) -->
 <h2>:="$user['name']"</h2>
 <h2>:='"Welcome back, {$user->name}"'</h2>
+<p>:="number_format($price, 2)"</p>
 
 <!-- Explicit (equals used, quotes required) -->
 <p><echo :="$description" /></p>
@@ -237,7 +238,7 @@ Values output using the engine are automatically wrapped in `htmlspecialchars()`
 
 5.2 **Whitelisted Functions**
 
-If you need to execute a core Arcane function (`php`, `scribe`, `relay`, `path`, `env`) and output raw, unescaped HTML, you can call them directly. They support both the `:<function>()` shorthand and the explicit `<function :="">` tag.
+If you need to execute a core Arcane function (`php`, `scribe`, `relay`, `path`, `env`) or output raw, unescaped HTML (like parsed Markdown or rich text), you can call them directly. They support both the `:<function>()` shorthand and the explicit `<function :="">` tag.
 
 ```html
 <!-- Shorthand (no equals, no quotes) -->
@@ -279,7 +280,7 @@ You can easily pull in other HTML partials, and developer comments are completel
 <include :="'partials/header.php'" />
 ```
 
-*Note on Performance:* Currently, Arcane evaluates these compiled HTML strings in memory (`eval`). This is fast and completely secure (since it only evaluates local `.html` files you write). It serves as a highly capable engine until future native integration with a file-based caching system is introduced to unlock maximum speeds.
+*Performance:* Currently, Arcane evaluates these compiled HTML strings in memory (`eval`). This is fast and completely secure (since it only evaluates local `.html` files you write). It serves as a highly capable engine until future native integration with a file-based caching system is introduced to unlock maximum speeds.
 
 ---
 
@@ -464,6 +465,7 @@ Arcane provides global constants to give you instant access to the application s
   - `PATH`: The resolved “base path” for the matched page.
   - `PATHS`: Hierarchical path list used for helper/asset discovery.
   - `PAGEFILE`: Absolute path to the resolved PHP page file.
+  - `VIEWFILE`: Absolute path to the uncompiled HTML view file (when used).
   - `LAYOUTFILE`: Absolute path to the resolved PHP layout file (when used).
 
 11.3 **Localization**:

--- a/README.md
+++ b/README.md
@@ -2,12 +2,13 @@
 
 > *Arcane is unconventional but beautifully intuitive. It is intentionally different, breaking away from modern frameworks to encourage critical thinking without the dependence and overhead of complex systems. It brings out the fun in building for the web by automating the features you want, while making it easier to apply the ones you need.*
 
-At its core, Arcane is a tiny `13kb` single-file PHP microframework designed to keep things easy and minimal. It uses a filesystem-first workflow where files map directly to routes, and context-aware helpers and assets load automatically. Perfect for anyone who wants a fast, flexible tool with zero setup.
+At its core, Arcane is a tiny `14kb` single-file PHP microframework designed to keep things easy and minimal. It uses a filesystem-first workflow where files map directly to routes, and context-aware helpers and assets load automatically. Perfect for anyone who wants a fast, flexible tool with zero setup.
 
   - Clean configuration free URLs
   - Unique filesystem defined routing
   - Helpers autoloaded by context
   - Layouts wrap pages automatically
+  - Optional MV engine compiled views
   - Robust localization kept simple
   - Architecture driven by directories
   - Simple ENV file configuration
@@ -35,14 +36,16 @@ Simply drop `index.php` into your project and open it in your browser. Arcane co
 2. [The Four Functions](#2-the-four-functions)
 3. [Routing & Pages](#3-routing--pages)
 4. [Layouts, Rendering, and Includes](#4-layouts-rendering-and-includes)
-5. [Helpers & Autoload Cascade](#5-helpers--autoload-cascade)
-6. [Automatic CSS/JS Assets](#6-automatic-cssjs-assets)
-7. [Localization and Translation](#7-localization-and-translation)
-8. [Environment & Settings](#8-environment--settings)
-9. [Page Directives](#9-page-directives)
-10. [Runtime Constants](#10-runtime-constants)
-11. [Troubleshooting & Notes](#11-troubleshooting--notes)
-12. [Requirements and Ecosystem](#12-requirements-and-ecosystem)
+5. [Optional Model-View Engine](#5-optional-model-view-engine)
+6. [Helpers & Autoload Cascade](#6-helpers--autoload-cascade)
+7. [Automatic CSS/JS Assets](#7-automatic-cssjs-assets)
+8. [Localization and Translation](#8-localization-and-translation)
+9. [Environment & Settings](#9-environment--settings)
+10. [Page Directives](#10-page-directives)
+11. [Runtime Constants](#11-runtime-constants)
+12. [Troubleshooting & Notes](#12-troubleshooting--notes)
+13. [Requirements and Ecosystem](#13-requirements-and-ecosystem)
+<!-- 14. [The Meaning of Arcane](#14-the-meaning-of-arcane) -->
 
 ---
 
@@ -61,7 +64,7 @@ Dependencies also break. They age, conflict, and require maintenance. Arcane sta
 Instead of a complex event loop, Arcane follows a linear path of discovery:
 
 1. **Match:** The URL is mapped directly to the closest physical file in `/pages`, normalizing paths for SEO.
-2. **Collect:** Arcane walks the directory tree down to that file, channels only relevant helpers, data, and assets.
+2. **Collect:** Arcane walks the directory tree down to that file, channeling only relevant helpers, data, and assets.
 3. **Build:** The page executes within this prepared environment, generating the `CONTENT` constant.
 4. **Return:** Output is wrapped in the layout, assets are injected, and the final response is sent to the browser.
 
@@ -205,7 +208,82 @@ The layout automatically receives `CONTENT`, `STYLES`, and `SCRIPTS` as global c
 
 ---
 
-### 5. Helpers & Autoload Cascade
+### 5. Optional Model-View Engine
+
+Arcane ships with a built-in, regex-powered MV engine. Simply create an `.html` (View) file alongside your `.php` (Model) file. Your Model handles the data logic, and the engine compiles your View into native PHP for safe rendering.
+
+**The Golden Rule of Syntax:** If you use an equals sign (`=`), you must wrap your PHP expression in quotes. If you don't use an equals sign, no quotes are needed.
+
+5.1 **Auto-Escaped Variables**
+
+Values output using the engine are automatically wrapped in `htmlspecialchars()` to protect your application from XSS attacks by default.
+
+  - **Shorthand (`:`):** Best for simple variables and object methods (`:$title`, `:$user->getName()`). *Note: Shorthand does not support array brackets. Use the implicit echo instead.*
+  - **Implicit (`:=`):** Best for arrays, complex expressions, or string interpolation. When interpolating strings, use single quotes on the outside and double quotes on the inside: `:='"Welcome back, {$user->name}"'`.
+  - **Explicit (`<echo>`):** The explicit HTML-style tag for outputting expressions.
+
+```html
+<!-- Shorthand (no equals, no quotes) -->
+<h1>:$title</h1>
+<span>:$user->getName()</span>
+
+<!-- Implicit (equals used, quotes required) -->
+<h2>:="$user['name']"</h2>
+<h2>:='"Welcome back, {$user->name}"'</h2>
+
+<!-- Explicit (equals used, quotes required) -->
+<p><echo :="$description" /></p>
+```
+
+5.2 **Whitelisted Functions**
+
+If you need to execute a core Arcane function (`php`, `scribe`, `relay`, `path`, `env`) and output raw, unescaped HTML, you can call them directly. They support both the `:<function>()` shorthand and the explicit `<function :="">` tag.
+
+```html
+<!-- Shorthand (no equals, no quotes) -->
+<h2>:scribe('welcome_message')</h2>
+<link rel="stylesheet" href=":path('/css/style.css')" />
+
+<!-- Explicit (equals used, quotes required) -->
+<p><php :="'<strong>Raw Bold Text</strong>'" /></p>
+```
+
+5.3 **Control Structures**
+
+Arcane supports standard PHP control structures using clean HTML-style tags. The supported tags are `<if>`, `<elseif>`, `<else>`, `</if>`, `<foreach>`, `</foreach>`, `<break>`, and `<continue>`.
+
+```html
+<if :="$count > 0">
+  <p>You have items!</p>
+<elseif :="$count === 0">
+  <p>Your cart is empty.</p>
+<else>
+  <p>Please log in.</p>
+</if>
+
+<ul>
+  <foreach :="$users as $user">
+    <li>:$user->name</li>
+  </foreach>
+</ul>
+
+<input type="checkbox" <if :="$checked">checked</if> />
+```
+
+5.4 **Includes & Comments**
+
+You can easily pull in other HTML partials, and developer comments are completely stripped from the final compiled code. Included files inherit the exact same variable scope as the parent template.
+
+```html
+<-- This developer note will not appear in the DOM -->
+<include :="'partials/header.php'" />
+```
+
+*Note on Performance:* Currently, Arcane evaluates these compiled HTML strings in memory (`eval`). This is fast and completely secure (since it only evaluates local `.html` files you write). It serves as a highly capable engine until future native integration with a file-based caching system is introduced to unlock maximum speeds.
+
+---
+
+### 6. Helpers & Autoload Cascade
 
 This is one of Arcane's most "refreshing" features. Instead of autoloading every class in the universe, Arcane loads helpers based on context. Helpers are PHP files that return a value (`mixed`). They become variables in your page matching their filename.
 
@@ -251,7 +329,7 @@ return [
 
 ---
 
-### 6. Automatic CSS/JS Assets
+### 7. Automatic CSS/JS Assets
 
 Forget complicated configurations for simple tasks. Arcane uses *convention over wiring*.
 
@@ -269,7 +347,7 @@ For a user visiting `/blog/post` using the `default` layout, Arcane looks for an
 
 ---
 
-### 7. Localization and Translation
+### 8. Localization and Translation
 
 Arcane handles localization via folder naming conventions, supporting both language switching and country specific content.
 
@@ -321,7 +399,7 @@ Arcane weaves translations intelligently. For `en-us`, it loads:
 
   1. `locales/us.json` (country defaults)
   2. `locales/en/en.json` (language defaults)
-  3. `locales/es/en-us.json` (specific overrides)
+  3. `locales/en/en-us.json` (specific overrides)
 
 Later files override earlier ones, allowing you to define a base language and only tweak specific keys for countries.
 
@@ -329,11 +407,11 @@ Later files override earlier ones, allowing you to define a base language and on
 
 ---
 
-### 8. Environment & Settings
+### 9. Environment & Settings
 
 Configuration is handled via `.env`. If `.env` is missing, Arcane defaults to `.env.example`.
 
-8.1 **Key Settings (`SET_`)**:
+9.1 **Key Settings (`SET_`)**:
 
 | Setting | Default | Purpose |
 | :--- | :--- | :--- |
@@ -343,7 +421,7 @@ Configuration is handled via `.env`. If `.env` is missing, Arcane defaults to `.
 | `SET_LOCALE` | `null` | Set a default `BCP 47` tag to enable auto-localization. |
 | `SET_MINIFY` | `true` | Toggles HTML minification to keep output small. |
 
-8.2 **Directories (`DIR_`)**:
+9.2 **Directories (`DIR_`)**:
 
 You can remap any default folder (like `pages` to `views`) by setting `DIR_PAGES` in your environment.
 
@@ -359,7 +437,7 @@ DIR_IMAGES=/images/
 
 ---
 
-### 9. Page Directives
+### 10. Page Directives
 
 Directives are constants defined at the top of a *page* file. They act as the "controller" logic for that specific page.
 
@@ -369,18 +447,18 @@ Directives are constants defined at the top of a *page* file. They act as the "c
 
 ---
 
-### 10. Runtime Constants
+### 11. Runtime Constants
 
 Arcane provides global constants to give you instant access to the application state.
 
-10.1 **Content & Output**:
+11.1 **Content & Output**:
 
   - `CONTENT`: The rendered HTML of the page.
   - `HELPERS`: The merged and injected helpers for pages and layouts.
   - `STYLES`: The injected `<link>` tags (layout must be active).
   - `SCRIPTS`: The injected `<script>` tags (layout must be active).
 
-10.2 **Routing & Location**:
+11.2 **Routing & Location**:
 
   - `URI`: The URL segments array (locale segments removed when applicable).
   - `PATH`: The resolved “base path” for the matched page.
@@ -388,13 +466,13 @@ Arcane provides global constants to give you instant access to the application s
   - `PAGEFILE`: Absolute path to the resolved PHP page file.
   - `LAYOUTFILE`: Absolute path to the resolved PHP layout file (when used).
 
-10.3 **Localization**:
+11.3 **Localization**:
 
   - `LOCALES`: Discovered locales grouped by folder.
   - `LOCALE`: Array containing `CODE`, `COUNTRY`, `FILES`, `LANGUAGE`, and `URI` (when active).
   - `TRANSCRIPT`: The merged translations for the active locale (when active).
 
-10.4 **App Configuration**:
+11.4 **App Configuration**:
 
   - `APP`: Derived runtime info containing `DIR`, `ROOT`, `START`, `QUERY`, and `URI`.
   - `DIR`: Directory map (from defaults + any DIR_* overrides).
@@ -402,7 +480,7 @@ Arcane provides global constants to give you instant access to the application s
 
 ---
 
-### 11. Troubleshooting & Notes
+### 12. Troubleshooting & Notes
 
   - **Trailing Slashes**: Arcane normalizes "page-like" routes to have trailing slashes. This prevents duplicate content issues for SEO.
   - **Minification**: By default, `SET_MINIFY` is `true`. It strips whitespace and comments. If your HTML looks broken, try setting this to `false` in `.env` to debug.
@@ -411,7 +489,7 @@ Arcane provides global constants to give you instant access to the application s
 
 ---
 
-### 12. Requirements and Ecosystem
+### 13. Requirements and Ecosystem
 
 Arcane is minimal by design. It doesn't include heavy tomes, but it offers a system to plug them in easily.
 
@@ -431,7 +509,9 @@ location / {
 
 ---
 
-### 13. The Meaning of Arcane
+### 14. The Meaning of Arcane
+
+Since you made it this far down, here is a little easter egg message.
 
 The word *arcane* refers to mysterious knowledge, secrets understood by only a few.
 

--- a/README.md
+++ b/README.md
@@ -465,7 +465,7 @@ Arcane provides global constants to give you instant access to the application s
   - `PATH`: The resolved “base path” for the matched page.
   - `PATHS`: Hierarchical path list used for helper/asset discovery.
   - `PAGEFILE`: Absolute path to the resolved PHP page file.
-  - `VIEWFILE`: Absolute path to the uncompiled HTML view file (when used).
+  - `VIEWFILE`: Absolute path to the resolved HTML view file (when used).
   - `LAYOUTFILE`: Absolute path to the resolved PHP layout file (when used).
 
 11.3 **Localization**:

--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ The layout automatically receives `CONTENT`, `STYLES`, and `SCRIPTS` as global c
 
 ### 5. Optional Model-View Engine
 
-Arcane ships with a built-in, regex-powered MV engine. Simply create an `.html` (View) file alongside your `.php` (Model) file. Your Model handles the data logic, and the engine compiles your View into native PHP for safe rendering.
+Arcane ships with a built-in, regex-powered MV engine. Create an `.html` (view) file alongside your `.php` (model) file. Your model handles the data logic, while the engine compiles your view into native PHP for safe rendering.
 
 **The Golden Rule of Syntax:** If you use an equals sign (`=`), you must wrap your PHP expression in quotes. If you don't use an equals sign, no quotes are needed.
 

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "capachow/arcane",
     "type": "project",
-    "description": "A deceptively powerful 13kb dependency-free single-file PHP microframework built to keep things easy and minimal.",
+    "description": "A deceptively powerful 14kb dependency-free single-file PHP microframework built to keep things easy and minimal.",
     "keywords": [
         "php",
         "web-development",

--- a/index.php
+++ b/index.php
@@ -289,6 +289,51 @@
         extract(HELPERS, EXTR_SKIP);
 
         require PAGEFILE;
+
+        if (is_file($html = str_replace('.php', '.html', PAGEFILE))) {
+          if (!function_exists('php')) {
+            function php($value, $escape = false) {
+              if ($escape && $value) {
+                $value = htmlspecialchars($value, ENT_QUOTES);
+              }
+
+              return $value;
+            }
+          }
+
+          $html = preg_replace(str_replace([
+              '{attribute}', '{variable}', '{allow}', '{argument}'
+            ], [
+              ':\s*=\s*(?P<q>[\'"])(.*?)(?P=q)',
+              '\$[a-z_]\w*(->\w+(\s*\(([^()]|\([^()]*\))*\))?)*',
+              '(?:php|scribe|relay|path|env)',
+              '\(((?:[^()]|\([^()]*\))*)\)'
+            ], [
+            "/<--\s.*?-->/s",
+            "/<(if|elseif|foreach)\s+{attribute}\s*>/s",
+            "/<\/(if|foreach)>/",
+            "/<(else)\s*\/?>/",
+            "/<(break|continue)\s*\/?>/",
+            "/<include\s+{attribute}\s*\/?>/s",
+            "/<({allow})\s+{attribute}\s*\/?>/s",
+            "/(?:<echo\s+)?{attribute}(?:\s*\/?>)?/s",
+            "/:\s*=?\s*({allow}\s*{argument})/si",
+            "/:\s*=?\s*({variable})/i"
+          ]), [
+            '',
+            '<?php $1($3): ?>',
+            '<?php end$1; ?>',
+            '<?php $1: ?>',
+            '<?php $1; ?>',
+            '<?php include $2; ?>',
+            '<?= $1($3); ?>',
+            '<?= php($2, true); ?>',
+            '<?= $1; ?>',
+            '<?= php($1, true); ?>'
+          ], file_get_contents($html));
+
+          eval('?>' . $html);
+        }
       }, true);
     }
 

--- a/index.php
+++ b/index.php
@@ -285,12 +285,18 @@
     $path = PATH;
 
     if (defined('PAGEFILE')) {
+      $view = substr(PAGEFILE, 0, -4) . '.html';
+
+      if (is_file($view)) {
+        define('VIEWFILE', $view);
+      }
+
       relay('CONTENT', function () {
         extract(HELPERS, EXTR_SKIP);
 
         require PAGEFILE;
 
-        if (is_file($html = str_replace('.php', '.html', PAGEFILE))) {
+        if (defined('VIEWFILE')) {
           if (!function_exists('php')) {
             function php($value, $escape = false) {
               if ($escape && $value) {
@@ -301,7 +307,7 @@
             }
           }
 
-          $html = preg_replace(str_replace([
+          eval('?>' . preg_replace(str_replace([
               '{attribute}', '{variable}', '{allow}', '{argument}'
             ], [
               ':\s*=\s*(?P<q>[\'"])(.*?)(?P=q)',
@@ -330,9 +336,7 @@
             '<?= php($2, true); ?>',
             '<?= $1; ?>',
             '<?= php($1, true); ?>'
-          ], file_get_contents($html));
-
-          eval('?>' . $html);
+          ], file_get_contents(VIEWFILE)));
         }
       }, true);
     }

--- a/index.php
+++ b/index.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * Arcane 26.4.1 Microframework
+ * Arcane 26.4.2 Microframework
  * Copyright 2017-2026 Joshua Britt
  * MIT License https://arcane.dev
 **/


### PR DESCRIPTION
- Added a built-in Regex-powered Model-View Engine in ~40 lines of code (increasing total framework size to 14kb).
- Enabled auto-escaped variable output via shorthand (`:`) and implicit (`:=`) attributes to protect against XSS by default.
- Added support for PHP control structures using HTML-style tags (`<if>`, `<elseif>`, `<else>`, `<foreach>`, `<break>`, `<continue>`).
- Whitelisted core Arcane helpers (php, scribe, relay, path, env) for safe, raw HTML execution in templates.
- Implemented template partials via the <include> tag and added support for stripped <-- developer comments -->.
- Refactored engine syntax to strictly match the new modern PHP spacing standards (`if ()`, `elseif ()`) established on develop.
- Added comprehensive documentation (Section 5) to the README.md explaining the "Golden Rule" of the syntax and providing clear examples.
- Clarified the current in-memory execution (`eval()`) and set expectations for future file-caching performance updates.